### PR TITLE
Corrected declaration of jwt date claims to be integers not strings.

### DIFF
--- a/api/app/Models/AuthToken.php
+++ b/api/app/Models/AuthToken.php
@@ -38,9 +38,9 @@ class AuthToken extends BaseModel {
      * @var array
      */
     protected $casts = [
-        'nbf' => 'dateTime',
-        'iat' => 'dateTime',
-        'exp' => 'dateTime',
+        'nbf' => 'integer',
+        'iat' => 'integer',
+        'exp' => 'integer',
     ];
 
     /**

--- a/api/database/factories/ModelFactory.php
+++ b/api/database/factories/ModelFactory.php
@@ -57,9 +57,9 @@ $factory->defineAs(App\Models\AuthToken::class, 'body', function (Faker\Generato
         'iss' => $hostname,
         'aud' => str_replace('.api', '', $hostname),
         'sub' => $user['user_id'],
-        'nbf' => $now->toDateTimeString(),
-        'iat' => $now->toDateTimeString(),
-        'exp' => $now->addHour(1)->toDateTimeString(),
+        'nbf' => $now->timestamp,
+        'iat' => $now->timestamp,
+        'exp' => $now->addHour(1)->timestamp,
         'jti' => $faker->regexify('[A-Za-z0-9]{8}'),
         '#user' => $user,
     ];


### PR DESCRIPTION
sorry @artstorm, I made a mistake in the documentation - the date claims should be integers not iso8601 datetimestamps.
