### PR TITLE
docker 1.6.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(2) do |config|
 # provision apt update
   config.vm.provision :shell, inline: "apt-get update"
 # provision with docker
-  config.vm.provision :docker
+  config.vm.provision :docker, version: "1.6.2"
   config.vm.provision :docker_compose
 
 # Provision the box with boostrap file


### PR DESCRIPTION
latest docker version (1.7.0) has issues with exec
sticking to 1.6.2 for now
