### PR TITLE
Sets responder header Content-Type to application/json

### DIFF
--- a/api/src/Responder/Responder/ApiResponder.php
+++ b/api/src/Responder/Responder/ApiResponder.php
@@ -116,6 +116,7 @@ class ApiResponder extends BaseResponder implements ApiResponderInterface
     {
         $response = $this->getResponse();
         $response->setStatusCode($code);
+        $response->headers->set('Content-Type', 'application/json');
         $response->setContent($this->encode($this->getTransformer()->transformItem($item)));
         return $response;
     }
@@ -129,6 +130,7 @@ class ApiResponder extends BaseResponder implements ApiResponderInterface
     {
         $response = $this->getResponse();
         $response->setStatusCode($code);
+        $response->headers->set('Content-Type', 'application/json');
         $response->setContent($this->encode($this->getTransformer()->transformCollection($items)));
         return $response;
     }


### PR DESCRIPTION
The responder header Content-Type for collections and items should not
be set to text/html, but to application/json.
