### PR TITLE
Fix/articles crud seeding

### DIFF
--- a/api/app/Models/Article.php
+++ b/api/app/Models/Article.php
@@ -38,40 +38,24 @@ class Article extends BaseModel
         'article_id' => 'uuid',
         'title' => 'required|string',
         'content' => 'required|string',
-//        'permalink' => 'string|unique:article_permalinks,permalink'
+        'permalink' => 'string|unique:article_permalinks,permalink',
     ];
 
-//    /**
-//     * @param string $permalink
-//     */
-//    public function setPermalinkAttribute($permalink)
-//    {
-//        if ($permalink) {
-//            $this->attributes['permalink'] = $permalink;
-//            $permalinkObj = new ArticlePermalink();
-//            $permalinkObj->permalink = $permalink;
-//            $this->permalinks->add($permalinkObj);
-//        } else {
-//            $this->attributes['permalink'] = null;
-//        }
-//    }
 
-    /**
-     * @param string $permalinkSlug
-     */
-    public function setPermalinkAttribute($permalinkSlug)
+    private function savePermalink($permalinkSlug)
     {
         if ($permalinkSlug) {
             $permalink = new ArticlePermalink();
             $permalink->permalink = $permalinkSlug;
-
-            $this->permalinks()->save($permalink); //save to this model's permalink history
+            $permalink->article()->associate($this);
+            $permalink->save();
 
             $this->currentPermalink()->associate($permalink); //set permalink as this
 
         } else {
             $this->currentPermalink()->dissociate();
         }
+        return $this;
     }
 
 
@@ -82,6 +66,6 @@ class Article extends BaseModel
 
     public function permalinks()
     {
-        return $this->hasMany(ArticlePermalink::class, 'permalink');
+        return $this->hasMany(ArticlePermalink::class, 'article_id', 'article_id');
     }
 }

--- a/api/app/Models/Article.php
+++ b/api/app/Models/Article.php
@@ -38,28 +38,50 @@ class Article extends BaseModel
         'article_id' => 'uuid',
         'title' => 'required|string',
         'content' => 'required|string',
-        'permalink' => 'string|unique:article_permalinks,permalink'
+//        'permalink' => 'string|unique:article_permalinks,permalink'
     ];
 
+//    /**
+//     * @param string $permalink
+//     */
+//    public function setPermalinkAttribute($permalink)
+//    {
+//        if ($permalink) {
+//            $this->attributes['permalink'] = $permalink;
+//            $permalinkObj = new ArticlePermalink();
+//            $permalinkObj->permalink = $permalink;
+//            $this->permalinks->add($permalinkObj);
+//        } else {
+//            $this->attributes['permalink'] = null;
+//        }
+//    }
+
     /**
-     * @param string $permalink
+     * @param string $permalinkSlug
      */
-    public function setPermalinkAttribute($permalink)
+    public function setPermalinkAttribute($permalinkSlug)
     {
-        if ($permalink) {
-            $this->attributes['permalink'] = $permalink;
-            $permalinkObj = new ArticlePermalink();
-            $permalinkObj->permalink = $permalink;
-            $this->permalinks->add($permalinkObj);
+        if ($permalinkSlug) {
+            $permalink = new ArticlePermalink();
+            $permalink->permalink = $permalinkSlug;
+
+            $this->permalinks()->save($permalink); //save to this model's permalink history
+
+            $this->currentPermalink()->associate($permalink); //set permalink as this
+
         } else {
-            $this->attributes['permalink'] = null;
+            $this->currentPermalink()->dissociate();
         }
     }
 
 
+    public function currentPermalink()
+    {
+        return $this->belongsTo(ArticlePermalink::class, 'permalink');
+    }
+
     public function permalinks()
     {
-        $relation = $this->hasMany(ArticlePermalink::class, 'article_id', 'article_id');
-        return $relation;
+        return $this->hasMany(ArticlePermalink::class, 'permalink');
     }
 }

--- a/api/database/factories/ModelFactory.php
+++ b/api/database/factories/ModelFactory.php
@@ -110,22 +110,31 @@ $factory->define(App\Models\AuthToken::class, function ($faker) {
 
 $factory->define(App\Models\Article::class, function ($faker) {
     $publishedDatetime = $faker->optional(0.9)->dateTimeThisDecade();
-
-    $permalinks = [];
-
-    for ($i = rand(1, 10); $i >= 0; $i--) {
-        $permalinkObj = new \App\Models\ArticlePermalink();
-        $permalinkObj->permalink = str_random(255);
-        $permalinks[] = $permalinkObj;
-    }
+//
+//    $permalinks = [];
+//
+//    for ($i = rand(1, 10); $i >= 0; $i--) {
+//        $permalinkObj = new \App\Models\ArticlePermalink();
+//        $permalinkObj->permalink = str_random(255);
+//        $permalinks[] = $permalinkObj;
+//    }
 
 
     return [
         'article_id' => $faker->uuid,
         'title' => $faker->sentence,
         'content' => $content = implode("\n\n", $faker->paragraphs(3)),
-        'permalinks' => new \Spira\Repository\Collection\Collection($permalinks),
-        'permalink' => str_random(255),
+//        'permalinks' => new \Spira\Repository\Collection\Collection($permalinks),
+//        'permalink' => str_random(255),
         'first_published' => $publishedDatetime ? $publishedDatetime->format('Y-m-d H:i:s') : null,
     ];
+});
+
+
+$factory->define(App\Models\ArticlePermalink::class, function ($faker) {
+
+    return [
+        'permalink' => $faker->slug,
+    ];
+
 });

--- a/api/database/factories/ModelFactory.php
+++ b/api/database/factories/ModelFactory.php
@@ -110,22 +110,13 @@ $factory->define(App\Models\AuthToken::class, function ($faker) {
 
 $factory->define(App\Models\Article::class, function ($faker) {
     $publishedDatetime = $faker->optional(0.9)->dateTimeThisDecade();
-//
-//    $permalinks = [];
-//
-//    for ($i = rand(1, 10); $i >= 0; $i--) {
-//        $permalinkObj = new \App\Models\ArticlePermalink();
-//        $permalinkObj->permalink = str_random(255);
-//        $permalinks[] = $permalinkObj;
-//    }
-
 
     return [
         'article_id' => $faker->uuid,
         'title' => $faker->sentence,
         'content' => $content = implode("\n\n", $faker->paragraphs(3)),
-//        'permalinks' => new \Spira\Repository\Collection\Collection($permalinks),
-//        'permalink' => str_random(255),
+//        'permalink' => $faker->unique()->optional(0.9)->slug,
+        'permalink' => null, //@todo switch this out for the above permalink definition
         'first_published' => $publishedDatetime ? $publishedDatetime->format('Y-m-d H:i:s') : null,
     ];
 });
@@ -134,7 +125,7 @@ $factory->define(App\Models\Article::class, function ($faker) {
 $factory->define(App\Models\ArticlePermalink::class, function ($faker) {
 
     return [
-        'permalink' => $faker->slug,
+        'permalink' => $faker->unique()->slug,
     ];
 
 });

--- a/api/database/migrations/2015_07_21_144631_create_articles_permalinks_table.php
+++ b/api/database/migrations/2015_07_21_144631_create_articles_permalinks_table.php
@@ -33,6 +33,6 @@ class CreateArticlesPermalinksTable extends Migration
      */
     public function down()
     {
-        Schema::drop(\App\Models\ArticlePermalink::getTableName());
+        DB::statement(sprintf('DROP TABLE %s CASCADE', \App\Models\ArticlePermalink::getTableName()));
     }
 }

--- a/api/database/migrations/2015_07_28_005041_add_permalink_foreign_key_to_articles_table.php
+++ b/api/database/migrations/2015_07_28_005041_add_permalink_foreign_key_to_articles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPermalinkForeignKeyToArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(\App\Models\Article::getTableName(), function (Blueprint $table) {
+            $table->foreign('permalink')
+                ->references('permalink')->on(\App\Models\ArticlePermalink::getTableName());
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(\App\Models\Article::getTableName(), function (Blueprint $table) {
+            $table->dropForeign('articles_permalink_foreign');
+        });
+    }
+}

--- a/api/database/seeds/ArticleSeeder.php
+++ b/api/database/seeds/ArticleSeeder.php
@@ -17,15 +17,15 @@ class ArticleSeeder extends Seeder
 
         factory(App\Models\Article::class, 10)
             ->create()
-            ->each(function(\App\Models\Article $article) {
-                $permalink = factory(App\Models\ArticlePermalink::class)->make();
+            ->each(function(\App\Models\Article $article) use ($faker) {
 
-                $permalink->article()->associate($article);
-                $permalink->save();
+                foreach(range(0,$faker->numberBetween(0, 4)) as $index){
+                    $permalink = factory(App\Models\ArticlePermalink::class)->make();
+                    $permalink->article()->associate($article);
+                    $permalink->save();
+                }
 
-                $article->currentPermalink()->associate($permalink);
-                $article->save();
-
-            });
+            })
+        ;
     }
 }

--- a/api/database/seeds/ArticleSeeder.php
+++ b/api/database/seeds/ArticleSeeder.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Database\Seeder;
 
+use Faker\Factory as Faker;
+
 class ArticleSeeder extends Seeder
 {
     /**
@@ -11,6 +13,19 @@ class ArticleSeeder extends Seeder
      */
     public function run()
     {
-        factory(App\Models\Article::class, 10)->create();
+        $faker = Faker::create('au_AU');
+
+        factory(App\Models\Article::class, 10)
+            ->create()
+            ->each(function(\App\Models\Article $article) {
+                $permalink = factory(App\Models\ArticlePermalink::class)->make();
+
+                $permalink->article()->associate($article);
+                $permalink->save();
+
+                $article->currentPermalink()->associate($permalink);
+                $article->save();
+
+            });
     }
 }


### PR DESCRIPTION
@Redjik I have added foreign key constraints, and reworked the relationships a bit to make sure the seeders work. It is critical for testing the frontend that the seeders can fill the tables with representative models from the model factories.

I have made a start on how the permalink saving could work; see `Article::savePermalink` however I found I wasn't able to get the function to work as a post save method due to the save method not being found on the model? Can you look into this issue and make sure that the article permalinks are only saved when the article is saved. 

We can't have it on setPermalinkAttribute as that happens before the article is written to database, which would cause a foreign key constraint violation on the `article_permalinks.article_id` as the article has not been saved yet. Therefore we must write the permalink to database _after_ the article is saved.

I attempted adding methods to the ArticlesRepository, however that is not workable as the seeders are not repository aware, so the seeders will fail.
