### PR TITLE
Hotfix/social login redirect

### DIFF
--- a/.secret.env.example
+++ b/.secret.env.example
@@ -1,6 +1,11 @@
+# set up facebook app at https://developers.facebook.com/apps/
 PROVIDER_FACEBOOK_CLIENT_ID=-your-facebook-client-id
 PROVIDER_FACEBOOK_CLIENT_SECRET=your-facebook-client-secret
+
+# set up twitter app at https://apps.twitter.com/
 PROVIDER_TWITTER_CLIENT_ID=your-twitter-client-id
 PROVIDER_TWITTER_CLIENT_SECRET=your-twitter-client-id
+
+# set up google by following steps in https://developers.google.com/identity/toolkit/web/configure-service
 PROVIDER_GOOGLE_CLIENT_ID=your-google-client-id
 PROVIDER_GOOGLE_CLIENT_SECRET=your-google-client-id

--- a/api/app/Extensions/Socialite/SocialiteServiceProvider.php
+++ b/api/app/Extensions/Socialite/SocialiteServiceProvider.php
@@ -38,7 +38,7 @@ class SocialiteServiceProvider extends ServiceProvider
     public function registerServiceRedirects()
     {
         $services = array_keys($this->app['config']['services']);
-        $host = $this->app['config']['hosts.api'];
+        $host = $this->app['config']['hosts.app'];
 
         foreach ($services as $service) {
             $url = sprintf('%s/auth/social/%s/callback', $host, $service);

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -204,7 +204,7 @@ class AuthController extends ApiController
 
         // Prepare response data
         $token = $this->jwtAuth->fromUser($user, ['method' => $provider]);
-        $returnUrl = $socialite->with($provider)->getCachedReturnUrl();
+        $returnUrl = $socialite->with($provider)->getCachedReturnUrl() . '?jwtAuthToken=' . $token;
 
         $response = $this->getResponse()->header('Authorization-Update', 'Bearer '.$token);
         $response->redirect($returnUrl, 302);

--- a/api/resources/views/documentation/sections/auth.blade.apib
+++ b/api/resources/views/documentation/sections/auth.blade.apib
@@ -88,7 +88,7 @@ A user can login by using a social profile as identification.
 + Response 302
     + Headers
 
-        Location: https://www.facebook.com/v2.4/dialog/oauth?client_id=457398928507539&redirect_uri=http%3A%2F%2Fapi.spira.io%2Fauth%2Fsocial%2Ffacebook%2Fcallback&scope=email&response_type=code&state=PdUvOcZpQ9FdxIlyoGXEdJ9zFPh5AqK0NUDiQa5F
+            Location: https://www.facebook.com/v2.4/dialog/oauth?client_id=457398928507539&redirect_uri=http%3A%2F%2Fapi.spira.io%2Fauth%2Fsocial%2Ffacebook%2Fcallback&scope=email&response_type=code&state=PdUvOcZpQ9FdxIlyoGXEdJ9zFPh5AqK0NUDiQa5F
 
 ## Social Login Callback [/auth/social/{provider}/callback]
 
@@ -103,5 +103,6 @@ to the application with the authentication details to this route.
 + Response 302
 
     + Headers
+    
             Location: http://spira.io?jwtAuthToken={!! $factory->make(\App\Models\AuthToken::class)->token !!}
 

--- a/api/resources/views/documentation/sections/auth.blade.apib
+++ b/api/resources/views/documentation/sections/auth.blade.apib
@@ -103,5 +103,5 @@ to the application with the authentication details to this route.
 + Response 302
 
     + Headers
-            Location: http://api.spira.io
-            Token: {!! $factory->make(\App\Models\AuthToken::class)->token !!}
+            Location: http://spira.io?jwtAuthToken={!! $factory->make(\App\Models\AuthToken::class)->token !!}
+

--- a/api/tests/integration/AuthTest.php
+++ b/api/tests/integration/AuthTest.php
@@ -399,7 +399,7 @@ class AuthTest extends TestCase
         $array = json_decode($this->response->getContent(), true);
         $this->assertEquals('facebook', $decoded['method']);
         $this->assertTrue($this->response->headers->has('location'), 'Response has location header.');
-        $this->assertEquals('http://foo.bar', $this->response->headers->get('location'));
+        $this->assertStringStartsWith('http://foo.bar', $this->response->headers->get('location'));
 
         // Assert that the social login was created
         $user = User::find($user->user_id);
@@ -437,7 +437,7 @@ class AuthTest extends TestCase
         $array = json_decode($this->response->getContent(), true);
         $this->assertEquals('facebook', $decoded['method']);
         $this->assertTrue($this->response->headers->has('location'), 'Response has location header.');
-        $this->assertEquals('http://foo.bar', $this->response->headers->get('location'));
+        $this->assertStringStartsWith('http://foo.bar', $this->response->headers->get('location'));
 
         // Assert that the social login was created
         $user = User::find($decoded['sub']);

--- a/app/src/app/guest/login/login.spec.ts
+++ b/app/src/app/guest/login/login.spec.ts
@@ -11,7 +11,7 @@ describe('Login', () => {
 
                 deferredCreds.promise.then(null, null, (creds) => {
                     if (creds.password == 'fail'){
-                        deferred.notify(new NgJwtAuth.NgJwtAuthException('error'));
+                        deferred.notify(new NgJwtAuth.NgJwtAuthCredentialsFailedException('error'));
                     }else{
                         deferred.resolve('success');
                         deferredCreds.resolve(creds);

--- a/app/src/app/guest/login/login.ts
+++ b/app/src/app/guest/login/login.ts
@@ -26,7 +26,7 @@ module app.guest.login {
 
     class LoginInit {
 
-        static $inject = ['$rootScope', 'ngJwtAuthService', '$mdDialog', '$timeout', '$window', '$state', '$q'];
+        static $inject = ['$rootScope', 'ngJwtAuthService', '$mdDialog', '$timeout', '$window', '$state', '$q', '$location'];
         constructor(
             private $rootScope:global.IRootScope,
             private ngJwtAuthService:NgJwtAuth.NgJwtAuthService,
@@ -36,31 +36,6 @@ module app.guest.login {
             private $state:ng.ui.IStateService,
             private $q:ng.IQService
         ) {
-
-            ngJwtAuthService
-                .registerUserFactory((subClaim: string, tokenData: global.JwtAuthClaims): ng.IPromise<common.models.User> => {
-                    return this.$q.when(new common.models.User(tokenData._user));
-                })
-                .registerLoginPromptFactory((deferredCredentials:ng.IDeferred<NgJwtAuth.ICredentials>, loginSuccessPromise:ng.IPromise<NgJwtAuth.IUser>, currentUser:NgJwtAuth.IUser): ng.IPromise<any> => {
-
-                    let dialogConfig:ng.material.IDialogOptions = {
-                        templateUrl: 'templates/app/guest/login/login-dialog.tpl.html',
-                        controller: namespace+'.controller',
-                        clickOutsideToClose: true,
-                        locals : {
-                            deferredCredentials: deferredCredentials,
-                            loginSuccess: {
-                                promise: loginSuccessPromise //nest the promise in a function as otherwise material will try to wait for it to resolve
-                            },
-                        }
-                    };
-
-                    return $timeout(_.noop) //first do an empty timeout to allow the controllers to init if login prompt is fired from within a .run() phase
-                        .then(() => $mdDialog.show(dialogConfig));
-
-                })
-                .init(); //initialise the auth service (kicks off the timers etc)
-
 
 
             $rootScope.socialLogin = (type:string, redirectState:string = $state.current.name, redirectStateParams:Object = $state.current.params) => {

--- a/app/src/app/guest/login/login.ts
+++ b/app/src/app/guest/login/login.ts
@@ -103,7 +103,7 @@ module app.guest.login {
                 (user) => $mdDialog.hide(user), //on success hide the dialog, pass through the returned user object
                 null,
                 (err:Error) => {
-                    if (err instanceof NgJwtAuth.NgJwtAuthException){
+                    if (err instanceof NgJwtAuth.NgJwtAuthCredentialsFailedException){
                         this.$mdToast.show(
                             (<any>$mdToast).simple() //<any> added so the parent method doesn't throw error, see https://github.com/borisyankov/DefinitelyTyped/issues/4843#issuecomment-124443371
                                 .hideDelay(2000)
@@ -111,6 +111,8 @@ module app.guest.login {
                                 .content(err.message)
                                 .parent('#loginDialog')
                         );
+                    }else{
+                        console.error(err);
                     }
                 }
             );

--- a/app/src/common/services/authService.ts
+++ b/app/src/common/services/authService.ts
@@ -62,8 +62,10 @@ module common.services.auth {
 
         private processQueryToken():ng.IPromise<any> {
 
+            this.removeFacebookHash();
             let queryParams = this.$location.search();
             if (queryParams.jwtAuthToken) {
+
                 let queryTokenPromise = this.ngJwtAuthService.processNewToken(queryParams.jwtAuthToken);
 
                 this.$location.search('jwtAuthToken', null);
@@ -72,6 +74,17 @@ module common.services.auth {
             }
 
             return this.$q.when(true); //immediately resolve
+
+        }
+
+        /**
+         * Removes the facebook return hash `#_=_`
+         */
+        private removeFacebookHash():void {
+
+            if (this.$location.hash() == '_=_'){
+                this.$location.hash('');
+            }
 
         }
 

--- a/app/src/common/services/authService.ts
+++ b/app/src/common/services/authService.ts
@@ -1,0 +1,104 @@
+module common.services.auth {
+
+    export const namespace = 'common.services.auth';
+
+    export class AuthService {
+
+        public initialisedPromise:ng.IPromise<any>;
+
+        static $inject:string[] = ['ngJwtAuthService', '$q', '$location', '$timeout', '$mdDialog', '$state', '$mdToast'];
+
+        constructor(private ngJwtAuthService:NgJwtAuth.NgJwtAuthService,
+                    private $q:ng.IQService,
+                    private $location:ng.ILocationService,
+                    private $timeout:ng.ITimeoutService,
+                    private $mdDialog:ng.material.IDialogService,
+                    private $state:ng.ui.IStateService,
+                    private $mdToast:ng.material.IToastService
+        ) {
+
+            this.initialisedPromise = this.initialiseJwtAuthService().finally(() => {
+
+                return this.$q.all([
+                    this.processQueryToken(),
+                    this.processPasswordResetToken()
+                ]);
+
+            }).catch((e) => {
+                console.error("Auth Initialisation failed: ", e);
+            });
+
+        }
+
+        private initialiseJwtAuthService() {
+
+            let jwtAuthServiceInitialisedPromise = this.ngJwtAuthService
+                .registerUserFactory((subClaim: string, tokenData: global.JwtAuthClaims): ng.IPromise<common.models.User> => {
+                    return this.$q.when(new common.models.User(tokenData._user));
+                })
+                .registerLoginPromptFactory((deferredCredentials:ng.IDeferred<NgJwtAuth.ICredentials>, loginSuccessPromise:ng.IPromise<NgJwtAuth.IUser>, currentUser:NgJwtAuth.IUser): ng.IPromise<any> => {
+
+                    let dialogConfig:ng.material.IDialogOptions = {
+                        templateUrl: 'templates/app/guest/login/login-dialog.tpl.html',
+                        controller: 'app.guest.login.controller',
+                        clickOutsideToClose: true,
+                        locals : {
+                            deferredCredentials: deferredCredentials,
+                            loginSuccess: {
+                                promise: loginSuccessPromise //nest the promise in a function as otherwise material will try to wait for it to resolve
+                            },
+                        }
+                    };
+
+                    return this.$timeout(_.noop) //first do an empty timeout to allow the controllers to init if login prompt is fired from within a .run() phase
+                        .then(() => this.$mdDialog.show(dialogConfig));
+
+                })
+                .init(); //initialise the auth service (kicks off the timers etc)
+
+            return jwtAuthServiceInitialisedPromise;
+
+        }
+
+        private processQueryToken():ng.IPromise<any> {
+
+            let queryParams = this.$location.search();
+            if (queryParams.jwtAuthToken) {
+                let queryTokenPromise = this.ngJwtAuthService.processNewToken(queryParams.jwtAuthToken);
+
+                this.$location.search('jwtAuthToken', null);
+
+                return queryTokenPromise;
+            }
+
+            return this.$q.when(true); //immediately resolve
+
+        }
+
+        private processPasswordResetToken():ng.IPromise<any> {
+
+            let queryParams = this.$location.search();
+            if (_.isEmpty(queryParams.passwordResetToken)) {
+                return this.$q.when(true); //immediately resolve
+            }
+
+            return this.ngJwtAuthService.exchangeToken(queryParams.passwordResetToken)
+                .then(null, (err) => {
+                    this.$mdToast.show(
+                        this.$mdToast.simple()
+                            .hideDelay(2000)
+                            .position('top right')
+                            .content("Sorry, you have already tried to reset your password using this link")
+                    );
+                });
+        }
+
+    }
+
+    angular.module(namespace, [])
+        .service('authService', AuthService);
+
+}
+
+
+

--- a/app/src/common/services/services.ts
+++ b/app/src/common/services/services.ts
@@ -3,6 +3,7 @@ module common.services {
     export const namespace = 'common.services';
 
     angular.module(namespace, [
+        namespace+'.auth',
         namespace+'.user',
         namespace+'.article',
         namespace+'.countries',

--- a/app/src/config/stateManager.ts
+++ b/app/src/config/stateManager.ts
@@ -70,10 +70,8 @@ module config.stateManager {
 
                     event.preventDefault();
 
-                    console.log('stopping to check authService is initialised');
                     //defer prompting for login until the auth service has completed all checks
                     this.authService.initialisedPromise.finally(() => {
-                        console.log('auth service initialised');
                         this.showLoginAndRedirectTo(toState, toParams, fromState);
                     });
 

--- a/app/src/config/stateManager.ts
+++ b/app/src/config/stateManager.ts
@@ -49,16 +49,17 @@ module config.stateManager {
 
     class StateManagerInit {
 
-        static $inject = ['$rootScope', 'ngRestAdapter', 'ngJwtAuthService', '$state', '$mdToast'];
+        static $inject = ['$rootScope', 'ngRestAdapter', 'ngJwtAuthService', '$state', '$mdToast', 'authService'];
 
         constructor(private $rootScope:ng.IRootScopeService,
                     private ngRestAdapter:NgRestAdapter.NgRestAdapterService,
                     private ngJwtAuthService:NgJwtAuth.NgJwtAuthService,
                     private $state:ng.ui.IStateService,
-                    private $mdToast:ng.material.IToastService) {
+                    private $mdToast:ng.material.IToastService,
+                    private authService:common.services.auth.AuthService
+        ) {
 
             this.registerStatePermissions();
-
         }
 
         private registerStatePermissions = () => {
@@ -69,24 +70,13 @@ module config.stateManager {
 
                     event.preventDefault();
 
-                    //check to see if a password reset token is provided and use that if so
-                    if(!_.isEmpty(toParams['passwordResetToken'])) {
-                        this.ngJwtAuthService.exchangeToken(toParams['passwordResetToken'])
-                            .then(() => {
-                                this.$state.go(toState.name, toParams);
-                            }, (err) => {
-                                this.$mdToast.show(
-                                    this.$mdToast.simple()
-                                        .hideDelay(2000)
-                                        .position('top right')
-                                        .content("Sorry, you have already tried to reset your password using this link")
-                                );
-                                this.showLoginAndRedirectTo(toState, toParams, fromState);
-                            });
-                    }
-                    else {
+                    console.log('stopping to check authService is initialised');
+                    //defer prompting for login until the auth service has completed all checks
+                    this.authService.initialisedPromise.finally(() => {
+                        console.log('auth service initialised');
                         this.showLoginAndRedirectTo(toState, toParams, fromState);
-                    }
+                    });
+
                 }
 
             })


### PR DESCRIPTION
This pr changes the social login flow to use query params rather than headers. It also refactors the intial login checks for updated passwords and login tokens to a service that returns a promise so the state interceptor can wait until initialisation is complete before prompting the user to log in.
