### PR TITLE
Fixed too many connections issues by moving the Illuminate\Foundation…

### DIFF
--- a/api/tests/Models/UserModelTest.php
+++ b/api/tests/Models/UserModelTest.php
@@ -5,7 +5,6 @@ use App\Models\SocialLogin;
 
 class UserModelTest extends TestCase
 {
-
     public function testUpdatingSocialLogin()
     {
         $user = factory(User::class)->create();

--- a/api/tests/Models/UserModelTest.php
+++ b/api/tests/Models/UserModelTest.php
@@ -2,11 +2,9 @@
 
 use App\Models\User;
 use App\Models\SocialLogin;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class UserModelTest extends TestCase
 {
-    use DatabaseTransactions;
 
     public function testUpdatingSocialLogin()
     {

--- a/api/tests/Repositories/ArticleRepositoryTest.php
+++ b/api/tests/Repositories/ArticleRepositoryTest.php
@@ -2,7 +2,6 @@
 use App\Models\Article;
 use App\Models\ArticlePermalink;
 use App\Repositories\ArticleRepository;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**
  * Created by PhpStorm.
@@ -14,7 +13,6 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ArticleRepositoryTest extends TestCase
 {
-    use DatabaseTransactions;
 
     /**
      * @var ArticleRepository

--- a/api/tests/Repositories/ArticleRepositoryTest.php
+++ b/api/tests/Repositories/ArticleRepositoryTest.php
@@ -13,7 +13,6 @@ use App\Repositories\ArticleRepository;
 
 class ArticleRepositoryTest extends TestCase
 {
-
     /**
      * @var ArticleRepository
      */

--- a/api/tests/Repositories/TestRepositoryTest.php
+++ b/api/tests/Repositories/TestRepositoryTest.php
@@ -1,15 +1,12 @@
 <?php
 
 use Mockery as m;
-use Rhumsaa\Uuid\Uuid;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**
  * @property \App\Repositories\BaseRepository $repository
  */
 class TestRepositoryTest extends TestCase
 {
-    use DatabaseTransactions;
 
     public function setUp()
     {

--- a/api/tests/Repositories/TestRepositoryTest.php
+++ b/api/tests/Repositories/TestRepositoryTest.php
@@ -7,7 +7,6 @@ use Mockery as m;
  */
 class TestRepositoryTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/api/tests/TestCase.php
+++ b/api/tests/TestCase.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+
 class TestCase extends Laravel\Lumen\Testing\TestCase
 {
     use AssertionsTrait, HelpersTrait;
@@ -11,9 +14,19 @@ class TestCase extends Laravel\Lumen\Testing\TestCase
      */
     public function setUp()
     {
+
         $this->bootTraits();
 
         parent::setUp();
+
+        DB::connection()->beginTransaction(); //start a new transaction
+    }
+
+    public function tearDown()
+    {
+        DB::connection()->rollBack(); //rollback the transaction so the test case can be rerun without duplicate key exceptions
+        DB::connection()->setPdo(null); //close the pdo connection to `avoid too many connections` errors
+        parent::tearDown();
     }
 
     /**

--- a/api/tests/TestCase.php
+++ b/api/tests/TestCase.php
@@ -14,7 +14,6 @@ class TestCase extends Laravel\Lumen\Testing\TestCase
      */
     public function setUp()
     {
-
         $this->bootTraits();
 
         parent::setUp();

--- a/api/tests/integration/ArticleTest.php
+++ b/api/tests/integration/ArticleTest.php
@@ -5,7 +5,6 @@ use App\Repositories\ArticleRepository;
 
 class ArticleTest extends TestCase
 {
-
     /**
      * @var ArticleRepository
      */

--- a/api/tests/integration/ArticleTest.php
+++ b/api/tests/integration/ArticleTest.php
@@ -2,11 +2,9 @@
 use App\Models\Article;
 use App\Models\ArticlePermalink;
 use App\Repositories\ArticleRepository;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ArticleTest extends TestCase
 {
-    use DatabaseTransactions;
 
     /**
      * @var ArticleRepository

--- a/api/tests/integration/AuthTest.php
+++ b/api/tests/integration/AuthTest.php
@@ -14,7 +14,6 @@ use Tymon\JWTAuth\Token;
 
 class AuthTest extends TestCase
 {
-
     protected function callRefreshToken($token)
     {
         $this->get('/auth/jwt/refresh', [

--- a/api/tests/integration/AuthTest.php
+++ b/api/tests/integration/AuthTest.php
@@ -2,7 +2,6 @@
 
 use App\Models\User;
 use GuzzleHttp\Client;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tymon\JWTAuth\Claims\Expiration;
 use Tymon\JWTAuth\Claims\IssuedAt;
 use Tymon\JWTAuth\Claims\Issuer;
@@ -15,7 +14,6 @@ use Tymon\JWTAuth\Token;
 
 class AuthTest extends TestCase
 {
-    use DatabaseTransactions;
 
     protected function callRefreshToken($token)
     {

--- a/api/tests/integration/EntityTest.php
+++ b/api/tests/integration/EntityTest.php
@@ -7,7 +7,6 @@ use Rhumsaa\Uuid\Uuid;
  */
 class EntityTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/api/tests/integration/EntityTest.php
+++ b/api/tests/integration/EntityTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Rhumsaa\Uuid\Uuid;
 
 /**
@@ -8,7 +7,6 @@ use Rhumsaa\Uuid\Uuid;
  */
 class EntityTest extends TestCase
 {
-    use DatabaseTransactions;
 
     public function setUp()
     {

--- a/api/tests/integration/UserTest.php
+++ b/api/tests/integration/UserTest.php
@@ -2,12 +2,10 @@
 
 use App\Models\User;
 use App\Models\UserCredential;
-use Rhumsaa\Uuid\Uuid;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class UserTest extends TestCase
 {
-    use DatabaseTransactions, MailcatcherTrait;
+    use MailcatcherTrait;
 
     public function setUp()
     {


### PR DESCRIPTION
…\Testing\DatabaseTransactions trait functionality to the base class, and closed the connection on each new test case
