### PR TITLE
Dropped all port forwarding from QA except 80

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -14,16 +14,12 @@ database:
   env_file:
     - .common.env
     - .qa.env
-  ports:
-    - "5432:5432"
 
 vanilladatabase:
   image: mariadb:10.0
   env_file:
     - .common.env
     - .local.env
-  ports:
-    - "3306:3306"
 
 cache:
   image: redis
@@ -78,7 +74,6 @@ web:
     - apimock:apimock
   ports:
     - "80:80"
-    - "8080:8080"
   env_file:
     - .common.env
     - .qa.env


### PR DESCRIPTION
Example of QA running alongside dev containers with no conflict

```
vagrant@spira-vagrant:/data$ docker-compose -p qa -f docker-compose.qa.yml up -d
Recreating qa_database_1...
Recreating qa_spira_1...
Recreating qa_logviewer_1...
Recreating qa_vanilladatabase_1...
Recreating qa_cache_1...
Recreating qa_mailcatcher_1...
Recreating qa_apimock_1...
Recreating qa_queue_1...
Recreating qa_php_1...
Recreating qa_web_1...
Recreating qa_devtools_1...
Recreating qa_queuerunner_1...
vagrant@spira-vagrant:/data$ docker-compose -p dev -f docker-compose.yml up -d
Creating dev_database_1...
Creating dev_vanilladatabase_1...
Creating dev_cache_1...
Creating dev_mailcatcher_1...
Creating dev_data_1...
Creating dev_apimock_1...
Creating dev_logviewer_1...
Creating dev_queue_1...
Creating dev_php_1...
Creating dev_web_1...
Creating dev_devtools_1...
Creating dev_queuerunner_1...
vagrant@spira-vagrant:/data$ docker-compose -p qa ps
        Name                      Command               State                    Ports
------------------------------------------------------------------------------------------------------
qa_apimock_1           /opt/bin/drakov-start.sh         Up       3000/tcp
qa_cache_1             /entrypoint.sh redis-server      Up       6379/tcp
qa_database_1          /docker-entrypoint.sh postgres   Up       5432/tcp
qa_devtools_1          /bin/bash -c ls -alh ${DAT ...   Exit 0
qa_logviewer_1         /opt/bin/clarity-start.sh        Up       8989/tcp
qa_mailcatcher_1       mailcatcher -f --ip=0.0.0.0      Up       1025/tcp, 1080/tcp
qa_php_1               /opt/bin/php-start.sh            Up       9000/tcp
qa_queue_1             beanstalkd -p 11300              Up       11300/tcp
qa_queuerunner_1       php artisan queue:listen - ...   Up
qa_vanilladatabase_1   /docker-entrypoint.sh mysqld     Up       3306/tcp
qa_web_1               /opt/bin/nginx-start.sh          Up       443/tcp, 0.0.0.0:81->80/tcp, 8080/tcp
vagrant@spira-vagrant:/data$ docker-compose -p dev ps
        Name                       Command               State                           Ports
---------------------------------------------------------------------------------------------------------------------
dev_apimock_1           /opt/bin/drakov-start.sh         Up       3000/tcp
dev_cache_1             /entrypoint.sh redis-server      Up       6379/tcp
dev_data_1              true                             Exit 0
dev_database_1          /docker-entrypoint.sh postgres   Up       0.0.0.0:5432->5432/tcp
dev_devtools_1          /bin/bash -c ls -alh ${DAT ...   Exit 0
dev_logviewer_1         /opt/bin/clarity-start.sh        Up       8989/tcp
dev_mailcatcher_1       mailcatcher -f --ip=0.0.0.0      Up       1025/tcp, 1080/tcp
dev_php_1               /opt/bin/php-start.sh            Up       9000/tcp
dev_queue_1             beanstalkd -p 11300              Up       11300/tcp
dev_queuerunner_1       php artisan queue:listen - ...   Up
dev_vanilladatabase_1   /docker-entrypoint.sh mysqld     Up       0.0.0.0:3306->3306/tcp
dev_web_1               /opt/bin/nginx-start.sh          Up       443/tcp, 0.0.0.0:80->80/tcp, 0.0.0.0:8080->8080/tcp
```
