### PR TITLE
Implements middleware to give Request a user resolver

### DIFF
--- a/api/app/Http/Middleware/UserResolverMiddleware.php
+++ b/api/app/Http/Middleware/UserResolverMiddleware.php
@@ -1,0 +1,44 @@
+<?php namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Extensions\JWTAuth\JWTAuth;
+
+class UserResolverMiddleware
+{
+    /**
+     * JWT Auth.
+     *
+     * @var JWTAuth
+     */
+    protected $jwtAuth;
+
+    /**
+     * Assign dependencies.
+     *
+     * @param  JWTAuth  $jwtAuth
+     *
+     * @return void
+     */
+    public function __construct(JWTAuth $jwtAuth)
+    {
+        $this->jwtAuth = $jwtAuth;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request->setUserResolver(function () {
+            return $this->jwtAuth->user();
+        });
+
+        return $next($request);
+    }
+}

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -58,7 +58,8 @@ $app->singleton(
 */
 
 $app->middleware([
-    'App\Http\Middleware\TransformInputDataMiddleware'
+    App\Http\Middleware\UserResolverMiddleware::class,
+    App\Http\Middleware\TransformInputDataMiddleware::class,
 //     // 'Illuminate\Cookie\Middleware\EncryptCookies',
 //     // 'Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse',
 //     // 'Illuminate\Session\Middleware\StartSession',

--- a/api/tests/MiddlewareTest.php
+++ b/api/tests/MiddlewareTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Http\Request;
+
 class MiddlewareTest extends TestCase
 {
     /**
@@ -51,5 +53,21 @@ class MiddlewareTest extends TestCase
         $this->assertArrayHasKey('nested_array', $request->all());
         $this->assertArrayHasKey('foo_bar', $request->nested_array);
         $this->assertArrayHasKey('and_this', $request->nested_array['one_more']);
+    }
+
+    public function testUserResolverMiddleware()
+    {
+        $user = $this->createUser();
+        $token = $this->tokenFromUser($user);
+
+        $request = $this->app->make(Request::class);
+        $request->headers->set('Authorization', 'Bearer '.$token);
+
+        $next = function ($request) { return $request; };
+        $mw = $this->app->make('App\Http\Middleware\UserResolverMiddleware');
+
+        $request = $mw->handle($request, $next);
+
+        $this->assertEquals($user->user_id, $request->user()->user_id);
     }
 }


### PR DESCRIPTION
I took a quick look at making the authed user available to the Request object. I'll correct myself for previously mentioning making our own driver. We should probably stick with the eloquent driver, as that is where our users originate from.

Instead giving the Request object a UserResolver does the trick.
