### PR TITLE
RequestEntity passed into getValidationRules method

### DIFF
--- a/api/app/Models/AbstractPost.php
+++ b/api/app/Models/AbstractPost.php
@@ -115,7 +115,7 @@ class AbstractPost extends IndexedModel implements LocalizableModelInterface
 
     protected $indexRelations = ['tags', 'permalinks', 'author', 'metas'];
 
-    public static function getValidationRules($entityId = null)
+    public static function getValidationRules($entityId = null, array $requestEntity = [])
     {
         return [
             'post_id' => 'required|uuid',

--- a/api/app/Models/PostComment.php
+++ b/api/app/Models/PostComment.php
@@ -46,7 +46,7 @@ class PostComment extends BaseModel
      *
      * @return array
      */
-    public static function getValidationRules($entityId = null)
+    public static function getValidationRules($entityId = null, array $requestEntity = [])
     {
         return [
             'user_id' => 'required|uuid',

--- a/api/app/Models/PostDiscussion.php
+++ b/api/app/Models/PostDiscussion.php
@@ -45,9 +45,9 @@ class PostDiscussion extends BaseModel implements VirtualRelationInterface
      *
      * @return array
      */
-    public static function getValidationRules($entityId = null)
+    public static function getValidationRules($entityId = null, array $requestEntity = [])
     {
-        return PostComment::getValidationRules($entityId);
+        return PostComment::getValidationRules($entityId, $requestEntity);
     }
 
     /**

--- a/api/app/Models/Section.php
+++ b/api/app/Models/Section.php
@@ -62,7 +62,7 @@ class Section extends BaseModel implements LocalizableModelInterface
         PromoContent::CONTENT_TYPE => PromoContent::class,
     ];
 
-    public static function getValidationRules($entityId = null)
+    public static function getValidationRules($entityId = null, array $requestEntity = [])
     {
         return [
             'section_id' => 'required|uuid',

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -70,7 +70,7 @@ class User extends IndexedModel implements AuthenticatableContract, SocialiteAut
      * @param null $entityId
      * @return array
      */
-    public static function getValidationRules($entityId = null)
+    public static function getValidationRules($entityId = null, array $requestEntity = [])
     {
         return [
             'user_id' => 'required|uuid',


### PR DESCRIPTION
Fixed failing tests on php 5.x because of strict standarts warnings
